### PR TITLE
App 6943 react-datetime not able to be used as a controlled component

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -384,10 +384,14 @@ var Datetime = createClass({
 	},
 
 	handleClickOutside: function() {
-		if ( this.props.input && this.state.open && this.props.open === undefined && !this.props.disableCloseOnClickOutside ) {
-			this.setState({ open: false }, function() {
+		if ( this.props.input && this.state.open ) {
+			if ( !this.props.open && !this.props.disableCloseOnClickOutside ) {
+				this.setState({ open: false }, function () {
+					this.props.onBlur( this.state.selectedDate || this.state.inputValue );
+				});
+			} else {
 				this.props.onBlur( this.state.selectedDate || this.state.inputValue );
-			});
+			}
 		}
 	},
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "dev": "./node_modules/.bin/webpack-dev-server --config example/webpack.config.js --devtool eval --progress --colors --hot --content-base example",
     "lint": "./node_modules/.bin/eslint src/ DateTime.js test/ && echo 'Linting OK! 💪'",
     "notify-pre-commit-hook": "echo '### Starting pre-commit hook 🦄'",
-    "test": "./node_modules/.bin/jest",
+    "test": "TZ=Europe/Stockholm ./node_modules/.bin/jest",
     "test:typings": "./node_modules/.bin/tsc -p ./typings",
-    "test:snapshot": "./node_modules/.bin/jest snapshot",
-    "test:snapshot:update": "./node_modules/.bin/jest snapshot --updateSnapshot",
+    "test:snapshot": "TZ=Europe/Stockholm ./node_modules/.bin/jest snapshot",
+    "test:snapshot:update": "TZ=Europe/Stockholm ./node_modules/.bin/jest snapshot --updateSnapshot",
     "test:all": "echo 'Running tests...' && npm run test:typings && npm run test && echo 'All tests passed! 🤘'",
     "test:watch": "./node_modules/.bin/jest --watch"
   },

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -941,6 +941,24 @@ describe('Datetime', () => {
 				utils.clickNthDay(component, 2);
 				expect(onBlurFn).not.toHaveBeenCalled();
 			});
+
+			it('when clicking outside', () => {
+				const onBlurFn = jest.fn(),
+					component = utils.createDatetime({ value: null, onBlur: onBlurFn, closeOnSelect: true });
+
+				utils.openDatepicker(component);
+				document.dispatchEvent(new Event('mousedown'));
+				expect(onBlurFn).toHaveBeenCalledTimes(1);
+			});
+
+			it('when clicking outside and open prop is true', () => {
+				const onBlurFn = jest.fn(),
+					component = utils.createDatetime({ value: null, onBlur: onBlurFn, closeOnSelect: true, open: true });
+
+				utils.openDatepicker(component);
+				document.dispatchEvent(new Event('mousedown'));
+				expect(onBlurFn).toHaveBeenCalledTimes(1);
+			});
 		});
 
 		it('onFocus when opening datepicker', () => {


### PR DESCRIPTION
### Description
Merge PR on upstream repo: Fixed onBlur not triggering when open or disableClickOutside are set to true https://github.com/YouCanBookMe/react-datetime/pull/573

### Motivation and Context

Fixes https://github.com/YouCanBookMe/react-datetime/issues/509

### Checklist

```
[x] I have not included any built dist files (us maintainers do that prior to a new release)
[x] I have added tests covering my changes
[x] All new and existing tests pass
[ ] My changes required the documentation to be updated
  [ ] I have updated the documentation accordingly
  [ ] I have updated the TypeScript 1.8 type definitions accordingly
  [ ] I have updated the TypeScript 2.0+ type definitions accordingly
```
